### PR TITLE
Fix config init to provide defaults

### DIFF
--- a/alpaca_bot/cli.py
+++ b/alpaca_bot/cli.py
@@ -7,15 +7,34 @@ import yaml
 
 from .config import Settings
 
+DEFAULT_CONFIG = {
+    "alpaca": {
+        "key_id": "",
+        "secret_key": "",
+        "base_url": "https://paper-api.alpaca.markets",
+    },
+    "execution": {
+        "mode": "paper",
+        "symbols": ["AAPL"],
+        "notional_max": 25000,
+        "timezone": "America/New_York",
+    },
+    "risk": {
+        "max_drawdown_pct": 10,
+        "max_position_pct": 30,
+        "min_equity_buffer_pct": 5,
+    },
+    "strategies": [],
+}
+
 app = typer.Typer(name="alpaca-bot")
 
 
 @app.command()
 def init(config_path: str = "config.yaml") -> None:
     """Create default config and .env files."""
-    cfg = Settings()
     path = Path(config_path)
-    path.write_text(yaml.safe_dump(cfg.model_dump(), sort_keys=False))
+    path.write_text(yaml.safe_dump(DEFAULT_CONFIG, sort_keys=False))
     env = Path(".env")
     if not env.exists():
         env.write_text("ALPACA_KEY_ID=\nALPACA_SECRET_KEY=\n")


### PR DESCRIPTION
## Summary
- ensure `alpaca-bot init` writes a default configuration
- keep tests passing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6840a141b4608327ad1d5725b278e202