### PR TITLE
Add CI workflow with linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          pip install .[dev]
+      - name: Ruff
+        run: |
+          ruff check .
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          pip install .[dev]
+      - name: Run tests
+        run: |
+          pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ alpaca-bot = "alpaca_bot.cli:main"
 dev = [
     "pytest",
     "pytest-cov",
+    "ruff",
 ]
 
 [tool.pytest.ini_options]
@@ -29,3 +30,9 @@ addopts = "-q --cov=alpaca_bot"
 [build-system]
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
+
+[tool.ruff]
+line-length = 120
+
+[tool.ruff.lint]
+select = ["E", "F"]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,5 @@
-import sys, types
+import sys
+import types
 
 # Minimal pydantic stub to satisfy imports during tests
 pydantic = types.ModuleType('pydantic')

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -1,4 +1,5 @@
 from decimal import Decimal
+import asyncio
 
 from alpaca_bot.execution.router import OrderRouter
 from alpaca_bot.execution.portfolio import Portfolio
@@ -12,7 +13,6 @@ class DummyClient:
         self.orders.append(order)
 
 
-import asyncio
 
 
 def test_order_router():

--- a/tests/test_strategy_loader.py
+++ b/tests/test_strategy_loader.py
@@ -7,7 +7,12 @@ def test_discover(tmp_path, monkeypatch):
     pkg.mkdir()
     (pkg / '__init__.py').write_text('')
     strategy_file = pkg / 's.py'
-    strategy_file.write_text('from alpaca_bot.strategy.base import BaseStrategy\nclass S(BaseStrategy):\n    def on_bar(self, bar):\n        return None\n')
+    strategy_file.write_text(
+        'from alpaca_bot.strategy.base import BaseStrategy\n'
+        'class S(BaseStrategy):\n'
+        '    def on_bar(self, bar):\n'
+        '        return None\n'
+    )
     sys.path.insert(0, str(tmp_path))
     monkeypatch.chdir(tmp_path)
     strategies = discover('pkg')


### PR DESCRIPTION
## Summary
- set up linting with ruff
- clean up test modules to satisfy linter
- add CI workflow to run ruff and pytest

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840b556e2088327bdca2f26e1a7bed1