### PR TITLE
Add Makefile for basic automation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,32 @@
+.PHONY: help setup run test lint clean
+
+VENV = .venv
+PYTHON = $(VENV)/bin/python
+PIP = $(VENV)/bin/pip
+
+help:
+	@echo "Available targets:"
+	@echo "  setup     - Create virtual environment and install dependencies"
+	@echo "  run       - Run the trading bot"
+	@echo "  test      - Run tests"
+	@echo "  lint      - Run ruff linter"
+	@echo "  clean     - Remove virtual environment"
+
+$(VENV)/bin/activate:
+	python3 -m venv $(VENV)
+	$(PIP) install --upgrade pip
+	$(PIP) install -e .[dev,web]
+
+setup: $(VENV)/bin/activate
+
+run: $(VENV)/bin/activate
+	$(VENV)/bin/alpaca-bot run --mode paper
+
+test: $(VENV)/bin/activate
+	$(VENV)/bin/pytest
+
+lint: $(VENV)/bin/activate
+	$(VENV)/bin/ruff .
+
+clean:
+	rm -rf $(VENV)

--- a/README.md
+++ b/README.md
@@ -55,6 +55,16 @@ An async trading bot framework. See the [technical brief](docs/TECHNICAL_BRIEF.m
 
    Open `http://localhost:8000` for the dashboard (requires web extras).
 
+## Using the Makefile
+
+A `Makefile` automates common tasks:
+
+```bash
+make setup  # create virtual environment and install dependencies
+make run    # run the bot
+make test   # run the tests
+```
+
 ### Adding strategies
 
 Place Python files defining subclasses of `BaseStrategy` in `strategies/` and reference them under `strategies:` in `config.yaml`.


### PR DESCRIPTION
## Summary
- provide Makefile helpers for setup, running, testing and linting
- document Makefile usage in README

## Testing
- `pytest -q`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6840bd056c3c83278255e77c314d0974