### PR TITLE
Add web optional extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ An async trading bot framework. See the [technical brief](docs/TECHNICAL_BRIEF.m
    ```bash
    pip install --editable .[web]
    ```
+   The `web` extras install `uvicorn` for the FastAPI dashboard.
 
 4. Initialise configuration:
 

--- a/docs/TECHNICAL_BRIEF.md
+++ b/docs/TECHNICAL_BRIEF.md
@@ -71,10 +71,11 @@ alpaca_bot/
 
 5. Quickstart (README excerpt)
 ------------------------------
-pipx install "alpaca-bot[web]"  
-alpaca-bot init  
-alpaca-bot run --mode paper  
-open http://localhost:8000  
+pipx install "alpaca-bot[web]"
+alpaca-bot init
+alpaca-bot run --mode paper
+# `[web]` installs `uvicorn` to serve the dashboard
+open http://localhost:8000
 
 6. Example config.yaml
 ----------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,9 @@ dev = [
     "pytest-cov",
     "ruff",
 ]
+web = [
+    "uvicorn",
+]
 
 [tool.pytest.ini_options]
 addopts = "-q --cov=alpaca_bot"


### PR DESCRIPTION
## Summary
- add `[project.optional-dependencies]` for `web`
- clarify README and technical brief about web extras

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6840c1d5cabc832793b7327f8f2889d3