### PR TITLE
Fix Makefile lint target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ test: $(VENV)/bin/activate
 	$(VENV)/bin/pytest
 
 lint: $(VENV)/bin/activate
-	$(VENV)/bin/ruff .
+	$(VENV)/bin/ruff check .
 
 clean:
 	rm -rf $(VENV)

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ A `Makefile` automates common tasks:
 make setup  # create virtual environment and install dependencies
 make run    # run the bot
 make test   # run the tests
+make lint   # run the Ruff linter
 ```
 
 ### Adding strategies

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
-pytest_plugins = ['pytest_cov']
-
 import pytest
+
+pytest_plugins = ['pytest_cov']
 
 @pytest.fixture(autouse=True)
 def alpaca_env(monkeypatch):


### PR DESCRIPTION
## Summary
- update Makefile to use `ruff check`
- document `make lint` in README
- reorder imports in `tests/conftest.py` for lint

## Testing
- `make lint`
- `make test`
- `make run`


------
https://chatgpt.com/codex/tasks/task_e_6840d0fdcd588327b3829aa52ca2a8ff