### PR TITLE
Ensure tests pass and add text UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,14 @@
 
 ## Running tests with coverage
 
-Run the test suite with Poetry to automatically generate a coverage report. The `pyproject.toml`
-configuration enables the `pytest-cov` plugin to collect coverage for the `alpaca_bot` package.
+Install the development dependencies and run the test suite to generate a
+coverage report. The `pyproject.toml` configuration already enables the
+`pytest-cov` plugin to collect coverage for the `alpaca_bot` package.
 
 ```bash
-poetry run pytest
+pip install -e .[dev]
+pytest
 ```
-=======
 
 An async trading bot framework. See the [technical brief](docs/TECHNICAL_BRIEF.md) for architecture details.
 
@@ -66,6 +67,7 @@ An async trading bot framework. See the [technical brief](docs/TECHNICAL_BRIEF.m
    Use additional commands like `alpaca-bot set-symbols "AAPL,MSFT"` to update
    trading symbols. `alpaca-bot portfolio` shows the current balance and P&L,
    while `alpaca-bot orders` lists open, closed and pending orders.
+   Launch `alpaca-bot tui` for an interactive text interface.
 
 ## Using the Makefile
 
@@ -81,6 +83,24 @@ make lint   # run the Ruff linter
 ### Adding strategies
 
 Place Python files defining subclasses of `BaseStrategy` in `strategies/` and reference them under `strategies:` in `config.yaml`.
+This repository provides several example strategies ready to use:
+
+* `strategies.moving_average.MovingAverageCross` – simple moving average crossover
+* `strategies.rsi_reversion.RSIReversion` – buys when RSI is oversold and sells when overbought
+* `strategies.scalping.MomentumScalper` – trades bar-to-bar momentum for quick scalps
+* `strategies.swing.SwingBreakout` – swing strategy buying breakouts and selling breakdowns
+* `strategies.composite.CompositeStrategy` – combine multiple strategies together
+
+Use them in your `config.yaml` like so:
+
+```yaml
+strategies:
+  - name: strategies.moving_average.MovingAverageCross
+    params: {fast: 5, slow: 20}
+  - name: strategies.rsi_reversion.RSIReversion
+    params: {period: 14}
+  - name: strategies.scalping.MomentumScalper
+```
 
 ### Tests and coverage
 

--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ This repository provides several example strategies ready to use:
 
 * `strategies.moving_average.MovingAverageCross` – simple moving average crossover
 * `strategies.rsi_reversion.RSIReversion` – buys when RSI is oversold and sells when overbought
-* `strategies.scalping.MomentumScalper` – trades bar-to-bar momentum for quick scalps
-* `strategies.swing.SwingBreakout` – swing strategy buying breakouts and selling breakdowns
+* `strategies.scalping.MomentumScalper` – uses a short-term moving average to scalp momentum
+* `strategies.swing.SwingBreakout` – breakout strategy with a trend filter for swing trades
 * `strategies.composite.CompositeStrategy` – combine multiple strategies together
 
 Use them in your `config.yaml` like so:
@@ -100,6 +100,7 @@ strategies:
   - name: strategies.rsi_reversion.RSIReversion
     params: {period: 14}
   - name: strategies.scalping.MomentumScalper
+    params: {period: 5}
 ```
 
 ### Tests and coverage

--- a/alpaca_bot/cli.py
+++ b/alpaca_bot/cli.py
@@ -105,6 +105,14 @@ def orders() -> None:
             typer.echo(f"  - {val}")
 
 
+@app.command()
+def tui() -> None:
+    """Start the interactive text UI."""
+    from .tui import run as run_tui
+
+    run_tui()
+
+
 def main() -> None:
     app()
 

--- a/alpaca_bot/tui.py
+++ b/alpaca_bot/tui.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from typing import Callable
+
+from . import cli
+
+
+def run(input_func: Callable[[str], str] = input) -> None:
+    """Simple text-based UI to control the bot."""
+    while True:
+        print("\n*** alpaca-bot menu ***")
+        print("1. Start bot")
+        print("2. Show portfolio")
+        print("3. Show orders")
+        print("4. Set symbols")
+        print("5. Quit")
+        choice = input_func("Select option: ").strip()
+        if choice == "1":
+            cli.run(no_ui=True)
+        elif choice == "2":
+            cli.portfolio()
+        elif choice == "3":
+            cli.orders()
+        elif choice == "4":
+            symbols = input_func("Symbols (comma-separated): ")
+            cli.set_symbols(symbols)
+        elif choice == "5":
+            break
+        else:
+            print("Invalid choice")

--- a/strategies/composite.py
+++ b/strategies/composite.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from typing import Iterable, List
+
+from alpaca_bot.strategy.base import BaseStrategy, Signal
+
+
+class CompositeStrategy(BaseStrategy):
+    """Combine multiple strategies and merge their signals."""
+
+    def __init__(self, strategies: Iterable[BaseStrategy]) -> None:
+        self.strategies = list(strategies)
+
+    def on_bar(self, bar) -> List[Signal] | None:
+        signals: List[Signal] = []
+        for strat in self.strategies:
+            res = strat.on_bar(bar)
+            if res:
+                signals.extend(res)
+        return signals or None

--- a/strategies/moving_average.py
+++ b/strategies/moving_average.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from collections import deque
+from decimal import Decimal
+from typing import Deque, List
+
+from alpaca_bot.strategy.base import BaseStrategy, Signal
+
+
+class MovingAverageCross(BaseStrategy):
+    """Simple moving average crossover strategy."""
+
+    def __init__(self, fast: int = 5, slow: int = 20) -> None:
+        if fast >= slow:
+            raise ValueError("fast period must be < slow period")
+        self.fast = fast
+        self.slow = slow
+        self.prices: Deque[Decimal] = deque(maxlen=slow)
+
+    def on_bar(self, bar) -> List[Signal] | None:
+        self.prices.append(bar.close)
+        if len(self.prices) < self.slow:
+            return None
+        fast_ma = sum(list(self.prices)[-self.fast:]) / Decimal(self.fast)
+        slow_ma = sum(self.prices) / Decimal(self.slow)
+        if fast_ma > slow_ma:
+            return [Signal("BUY", 100)]
+        elif fast_ma < slow_ma:
+            return [Signal("SELL", 100)]
+        return None

--- a/strategies/rsi_reversion.py
+++ b/strategies/rsi_reversion.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from collections import deque
+from decimal import Decimal
+from typing import Deque, List
+
+from alpaca_bot.strategy.base import BaseStrategy, Signal
+
+
+def _rsi(values: List[Decimal]) -> Decimal:
+    gains = [max(Decimal(0), values[i] - values[i - 1]) for i in range(1, len(values))]
+    losses = [max(Decimal(0), values[i - 1] - values[i]) for i in range(1, len(values))]
+    avg_gain = sum(gains) / Decimal(len(gains))
+    avg_loss = sum(losses) / Decimal(len(losses)) if sum(losses) > 0 else Decimal('1')
+    rs = avg_gain / avg_loss
+    return Decimal('100') - (Decimal('100') / (Decimal('1') + rs))
+
+
+class RSIReversion(BaseStrategy):
+    """Buy when RSI < 30, sell when RSI > 70."""
+
+    def __init__(self, period: int = 14) -> None:
+        self.period = period
+        self.prices: Deque[Decimal] = deque(maxlen=period + 1)
+
+    def on_bar(self, bar) -> List[Signal] | None:
+        self.prices.append(bar.close)
+        if len(self.prices) <= self.period:
+            return None
+        rsi = _rsi(list(self.prices))
+        if rsi < 30:
+            return [Signal("BUY", 100)]
+        if rsi > 70:
+            return [Signal("SELL", 100)]
+        return None

--- a/strategies/scalping.py
+++ b/strategies/scalping.py
@@ -1,16 +1,31 @@
 from __future__ import annotations
 
-from typing import List
+from collections import deque
+from decimal import Decimal
+from typing import Deque, List
 
 from alpaca_bot.strategy.base import BaseStrategy, Signal
 
 
 class MomentumScalper(BaseStrategy):
-    """Scalp small moves by looking at bar direction."""
+    """Scalp short-term momentum using a moving average filter."""
+
+    def __init__(self, period: int = 5) -> None:
+        self.period = period
+        self.closes: Deque[Decimal] = deque(maxlen=period + 1)
+
+    def _ma(self) -> Decimal:
+        recent = list(self.closes)[-self.period :]
+        return sum(recent) / Decimal(self.period)
 
     def on_bar(self, bar) -> List[Signal] | None:
-        if bar.close > bar.open:
+        self.closes.append(bar.close)
+        if len(self.closes) <= self.period:
+            return None
+        ma = self._ma()
+        prev_close = list(self.closes)[-2]
+        if bar.close > prev_close and bar.close > ma:
             return [Signal("BUY", 10)]
-        if bar.close < bar.open:
+        if bar.close < prev_close and bar.close < ma:
             return [Signal("SELL", 10)]
         return None

--- a/strategies/scalping.py
+++ b/strategies/scalping.py
@@ -7,8 +7,24 @@ from typing import Deque, List
 from alpaca_bot.strategy.base import BaseStrategy, Signal
 
 
+def _rsi(values: List[Decimal]) -> Decimal:
+    """Compute a minimal RSI value for the provided closing prices."""
+    gains = [max(Decimal(0), values[i] - values[i - 1]) for i in range(1, len(values))]
+    losses = [max(Decimal(0), values[i - 1] - values[i]) for i in range(1, len(values))]
+    avg_gain = sum(gains) / Decimal(len(gains))
+    avg_loss = sum(losses) / Decimal(len(losses)) if sum(losses) > 0 else Decimal("1")
+    rs = avg_gain / avg_loss
+    return Decimal("100") - (Decimal("100") / (Decimal("1") + rs))
+
+
 class MomentumScalper(BaseStrategy):
-    """Scalp short-term momentum using a moving average filter."""
+    """Scalping strategy combining momentum with RSI confirmation.
+
+    This strategy attempts to capture very short-term moves. It keeps a deque of
+    recent close prices so it can calculate a moving average and a simple RSI.
+    A long signal is emitted when price is rising, above its short MA and the
+    RSI shows strength. A short signal uses the opposite conditions.
+    """
 
     def __init__(self, period: int = 5) -> None:
         self.period = period
@@ -19,13 +35,21 @@ class MomentumScalper(BaseStrategy):
         return sum(recent) / Decimal(self.period)
 
     def on_bar(self, bar) -> List[Signal] | None:
+        """Generate trading signals on each bar."""
         self.closes.append(bar.close)
         if len(self.closes) <= self.period:
             return None
+
         ma = self._ma()
         prev_close = list(self.closes)[-2]
-        if bar.close > prev_close and bar.close > ma:
+        rsi = _rsi(list(self.closes)[-self.period - 1 :])
+
+        if bar.close > prev_close and bar.close > ma and rsi > 55:
+            # Strong upward momentum
             return [Signal("BUY", 10)]
-        if bar.close < prev_close and bar.close < ma:
+
+        if bar.close < prev_close and bar.close < ma and rsi < 45:
+            # Momentum to the downside
             return [Signal("SELL", 10)]
+
         return None

--- a/strategies/scalping.py
+++ b/strategies/scalping.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from typing import List
+
+from alpaca_bot.strategy.base import BaseStrategy, Signal
+
+
+class MomentumScalper(BaseStrategy):
+    """Scalp small moves by looking at bar direction."""
+
+    def on_bar(self, bar) -> List[Signal] | None:
+        if bar.close > bar.open:
+            return [Signal("BUY", 10)]
+        if bar.close < bar.open:
+            return [Signal("SELL", 10)]
+        return None

--- a/strategies/swing.py
+++ b/strategies/swing.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from collections import deque
+from decimal import Decimal
+from typing import Deque, List
+
+from alpaca_bot.strategy.base import BaseStrategy, Signal
+
+
+class SwingBreakout(BaseStrategy):
+    """Swing trading strategy that buys breakouts and sells breakdowns."""
+
+    def __init__(self, window: int = 5) -> None:
+        self.window = window
+        self.highs: Deque[Decimal] = deque(maxlen=window)
+        self.lows: Deque[Decimal] = deque(maxlen=window)
+
+    def on_bar(self, bar) -> List[Signal] | None:
+        prev_highs = list(self.highs)
+        prev_lows = list(self.lows)
+        self.highs.append(bar.high)
+        self.lows.append(bar.low)
+        if len(prev_highs) < self.window:
+            return None
+        if bar.close > max(prev_highs):
+            return [Signal("BUY", 100)]
+        if bar.close < min(prev_lows):
+            return [Signal("SELL", 100)]
+        return None

--- a/strategies/swing.py
+++ b/strategies/swing.py
@@ -7,19 +7,40 @@ from typing import Deque, List
 from alpaca_bot.strategy.base import BaseStrategy, Signal
 
 
-class SwingBreakout(BaseStrategy):
-    """Swing strategy buying breakouts with a trend filter."""
+def _rsi(values: List[Decimal]) -> Decimal:
+    """Compute RSI for the given closing prices."""
+    gains = [max(Decimal(0), values[i] - values[i - 1]) for i in range(1, len(values))]
+    losses = [max(Decimal(0), values[i - 1] - values[i]) for i in range(1, len(values))]
+    avg_gain = sum(gains) / Decimal(len(gains))
+    avg_loss = sum(losses) / Decimal(len(losses)) if sum(losses) > 0 else Decimal("1")
+    rs = avg_gain / avg_loss
+    return Decimal("100") - (Decimal("100") / (Decimal("1") + rs))
 
-    def __init__(self, window: int = 5, ma_period: int = 20) -> None:
+
+class SwingBreakout(BaseStrategy):
+    """Swing breakout strategy with trend and momentum confirmation.
+
+    The strategy looks for a break above the recent high (or below the recent
+    low) while the price is trending in that direction. A moving average is used
+    for trend confirmation and RSI helps avoid overbought/oversold entries.
+    """
+
+    def __init__(self, window: int = 5, ma_period: int = 20, rsi_period: int = 14) -> None:
         self.window = window
         self.ma_period = ma_period
+        self.rsi_period = rsi_period
+        size = max(ma_period, rsi_period) + 1
         self.highs: Deque[Decimal] = deque(maxlen=window)
         self.lows: Deque[Decimal] = deque(maxlen=window)
-        self.closes: Deque[Decimal] = deque(maxlen=ma_period)
+        self.closes: Deque[Decimal] = deque(maxlen=size)
 
     def _ma(self) -> Decimal:
         recent = list(self.closes)[-self.ma_period :]
         return sum(recent) / Decimal(self.ma_period)
+
+    def _rsi(self) -> Decimal:
+        recent = list(self.closes)[-self.rsi_period - 1 :]
+        return _rsi(recent)
 
     def on_bar(self, bar) -> List[Signal] | None:
         prev_highs = list(self.highs)
@@ -27,11 +48,19 @@ class SwingBreakout(BaseStrategy):
         self.highs.append(bar.high)
         self.lows.append(bar.low)
         self.closes.append(bar.close)
-        if len(prev_highs) < self.window or len(self.closes) < self.ma_period:
+
+        if len(prev_highs) < self.window or len(self.closes) <= max(self.ma_period, self.rsi_period):
             return None
+
         ma = self._ma()
-        if bar.close > ma and bar.close > max(prev_highs):
+        rsi = self._rsi()
+
+        if bar.close > ma and bar.close > max(prev_highs) and rsi > 60:
+            # Breakout to the upside with momentum
             return [Signal("BUY", 100)]
-        if bar.close < ma and bar.close < min(prev_lows):
+
+        if bar.close < ma and bar.close < min(prev_lows) and rsi < 40:
+            # Breakdown to the downside with weakness
             return [Signal("SELL", 100)]
+
         return None

--- a/strategies/swing.py
+++ b/strategies/swing.py
@@ -8,22 +8,30 @@ from alpaca_bot.strategy.base import BaseStrategy, Signal
 
 
 class SwingBreakout(BaseStrategy):
-    """Swing trading strategy that buys breakouts and sells breakdowns."""
+    """Swing strategy buying breakouts with a trend filter."""
 
-    def __init__(self, window: int = 5) -> None:
+    def __init__(self, window: int = 5, ma_period: int = 20) -> None:
         self.window = window
+        self.ma_period = ma_period
         self.highs: Deque[Decimal] = deque(maxlen=window)
         self.lows: Deque[Decimal] = deque(maxlen=window)
+        self.closes: Deque[Decimal] = deque(maxlen=ma_period)
+
+    def _ma(self) -> Decimal:
+        recent = list(self.closes)[-self.ma_period :]
+        return sum(recent) / Decimal(self.ma_period)
 
     def on_bar(self, bar) -> List[Signal] | None:
         prev_highs = list(self.highs)
         prev_lows = list(self.lows)
         self.highs.append(bar.high)
         self.lows.append(bar.low)
-        if len(prev_highs) < self.window:
+        self.closes.append(bar.close)
+        if len(prev_highs) < self.window or len(self.closes) < self.ma_period:
             return None
-        if bar.close > max(prev_highs):
+        ma = self._ma()
+        if bar.close > ma and bar.close > max(prev_highs):
             return [Signal("BUY", 100)]
-        if bar.close < min(prev_lows):
+        if bar.close < ma and bar.close < min(prev_lows):
             return [Signal("SELL", 100)]
         return None

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -49,23 +49,28 @@ def test_rsi_reversion():
 
 def test_momentum_scalper():
     scalper = MomentumScalper(period=2)
+    # Rising prices with strong momentum trigger a buy
     scalper.on_bar(make_bar(1, 1))
     scalper.on_bar(make_bar(2, 2))
-    sigs = scalper.on_bar(make_bar(3, 3))
+    sigs = scalper.on_bar(make_bar(4, 4))
     assert sigs and sigs[0].side == "BUY"
+
+    # Falling prices with weak momentum trigger a sell
     sigs = scalper.on_bar(make_bar(1, 1))
     assert sigs and sigs[0].side == "SELL"
 
 
 def test_swing_breakout():
-    swing = SwingBreakout(window=2, ma_period=3)
+    swing = SwingBreakout(window=2, ma_period=3, rsi_period=3)
     swing.on_bar(make_bar(1, 1, high=1, low=1))
-    swing.on_bar(make_bar(2, 2, high=2, low=2))
-    sigs = swing.on_bar(make_bar(3, 3, high=3, low=3))
+    swing.on_bar(make_bar(3, 3, high=3, low=3))
+    swing.on_bar(make_bar(5, 5, high=5, low=5))
+    sigs = swing.on_bar(make_bar(6, 6, high=6, low=6))
     assert sigs and sigs[0].side == "BUY"
 
-    swing = SwingBreakout(window=2, ma_period=3)
-    swing.on_bar(make_bar(3, 3, high=3, low=3))
+    swing = SwingBreakout(window=2, ma_period=3, rsi_period=3)
+    swing.on_bar(make_bar(6, 6, high=6, low=6))
+    swing.on_bar(make_bar(4, 4, high=4, low=4))
     swing.on_bar(make_bar(2, 2, high=2, low=2))
     sigs = swing.on_bar(make_bar(1, 1, high=1, low=1))
     assert sigs and sigs[0].side == "SELL"
@@ -77,5 +82,5 @@ def test_composite_strategy():
     comp = CompositeStrategy([ma, scalp])
     comp.on_bar(make_bar(1, 1))
     comp.on_bar(make_bar(2, 2))
-    sigs = comp.on_bar(make_bar(2, 3))
+    sigs = comp.on_bar(make_bar(2, 4))
     assert len(sigs) == 2

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -48,31 +48,32 @@ def test_rsi_reversion():
     assert sigs and sigs[0].side == "SELL"
 
 def test_momentum_scalper():
-    scalper = MomentumScalper()
-    sigs = scalper.on_bar(make_bar(1, 2))
+    scalper = MomentumScalper(period=2)
+    scalper.on_bar(make_bar(1, 1))
+    scalper.on_bar(make_bar(2, 2))
+    sigs = scalper.on_bar(make_bar(3, 3))
     assert sigs and sigs[0].side == "BUY"
-    sigs = scalper.on_bar(make_bar(2, 1))
+    sigs = scalper.on_bar(make_bar(1, 1))
     assert sigs and sigs[0].side == "SELL"
-    assert scalper.on_bar(make_bar(1, 1)) is None
 
 
 def test_swing_breakout():
-    swing = SwingBreakout(window=2)
+    swing = SwingBreakout(window=2, ma_period=3)
     swing.on_bar(make_bar(1, 1, high=1, low=1))
     swing.on_bar(make_bar(2, 2, high=2, low=2))
     sigs = swing.on_bar(make_bar(3, 3, high=3, low=3))
     assert sigs and sigs[0].side == "BUY"
 
-    swing = SwingBreakout(window=2)
+    swing = SwingBreakout(window=2, ma_period=3)
+    swing.on_bar(make_bar(3, 3, high=3, low=3))
     swing.on_bar(make_bar(2, 2, high=2, low=2))
-    swing.on_bar(make_bar(1, 1, high=1, low=1))
-    sigs = swing.on_bar(make_bar(0, 0, high=0, low=0))
+    sigs = swing.on_bar(make_bar(1, 1, high=1, low=1))
     assert sigs and sigs[0].side == "SELL"
 
 
 def test_composite_strategy():
     ma = MovingAverageCross(fast=2, slow=3)
-    scalp = MomentumScalper()
+    scalp = MomentumScalper(period=2)
     comp = CompositeStrategy([ma, scalp])
     comp.on_bar(make_bar(1, 1))
     comp.on_bar(make_bar(2, 2))

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -1,0 +1,80 @@
+from datetime import datetime
+from decimal import Decimal
+
+from alpaca_bot.core.models import Bar
+from strategies.moving_average import MovingAverageCross
+from strategies.rsi_reversion import RSIReversion
+from strategies.scalping import MomentumScalper
+from strategies.swing import SwingBreakout
+from strategies.composite import CompositeStrategy
+
+
+def make_bar(open_price: float, close_price: float, high: float | None = None, low: float | None = None) -> Bar:
+    high_val = Decimal(high if high is not None else max(open_price, close_price))
+    low_val = Decimal(low if low is not None else min(open_price, close_price))
+    return Bar(
+        "AAPL",
+        datetime(2024, 1, 1),
+        Decimal(open_price),
+        high_val,
+        low_val,
+        Decimal(close_price),
+        100,
+    )
+
+
+def test_moving_average_cross():
+    strat = MovingAverageCross(fast=2, slow=3)
+    strat.on_bar(make_bar(1, 1))
+    strat.on_bar(make_bar(2, 2))
+    sigs = strat.on_bar(make_bar(3, 3))
+    assert sigs and sigs[0].side == "BUY"
+    sigs = strat.on_bar(make_bar(0, 0))
+    assert sigs and sigs[0].side == "SELL"
+
+
+def test_rsi_reversion():
+    strat = RSIReversion(period=2)
+    strat.on_bar(make_bar(3, 3))
+    strat.on_bar(make_bar(2, 2))
+    sigs = strat.on_bar(make_bar(1, 1))
+    assert sigs and sigs[0].side == "BUY"
+
+    strat = RSIReversion(period=2)
+    strat.on_bar(make_bar(1, 1))
+    strat.on_bar(make_bar(2, 2))
+    sigs = strat.on_bar(make_bar(6, 6))
+
+    assert sigs and sigs[0].side == "SELL"
+
+def test_momentum_scalper():
+    scalper = MomentumScalper()
+    sigs = scalper.on_bar(make_bar(1, 2))
+    assert sigs and sigs[0].side == "BUY"
+    sigs = scalper.on_bar(make_bar(2, 1))
+    assert sigs and sigs[0].side == "SELL"
+    assert scalper.on_bar(make_bar(1, 1)) is None
+
+
+def test_swing_breakout():
+    swing = SwingBreakout(window=2)
+    swing.on_bar(make_bar(1, 1, high=1, low=1))
+    swing.on_bar(make_bar(2, 2, high=2, low=2))
+    sigs = swing.on_bar(make_bar(3, 3, high=3, low=3))
+    assert sigs and sigs[0].side == "BUY"
+
+    swing = SwingBreakout(window=2)
+    swing.on_bar(make_bar(2, 2, high=2, low=2))
+    swing.on_bar(make_bar(1, 1, high=1, low=1))
+    sigs = swing.on_bar(make_bar(0, 0, high=0, low=0))
+    assert sigs and sigs[0].side == "SELL"
+
+
+def test_composite_strategy():
+    ma = MovingAverageCross(fast=2, slow=3)
+    scalp = MomentumScalper()
+    comp = CompositeStrategy([ma, scalp])
+    comp.on_bar(make_bar(1, 1))
+    comp.on_bar(make_bar(2, 2))
+    sigs = comp.on_bar(make_bar(2, 3))
+    assert len(sigs) == 2

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1,0 +1,8 @@
+from alpaca_bot import tui
+
+
+def test_tui_quit(capsys):
+    inputs = iter(["5"])
+    tui.run(lambda _: next(inputs))
+    out = capsys.readouterr().out
+    assert "alpaca-bot menu" in out


### PR DESCRIPTION
## Summary
- document how to start the text UI from README
- expose `tui` command in CLI
- implement a simple text interface
- cover the new code with tests
- add two example strategies for moving average crossover and RSI reversion
- add scalping, swing, and composite strategies with unit tests

## Testing
- `pip install pytest pytest-cov ruff typer[all] pydantic pydantic-settings fastapi httpx websockets pyyaml uvicorn`
- `ruff check .`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c43cb71a48327b80f2dd9e45f5ba4